### PR TITLE
Refactor Phaser entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,5 @@
 </head>
 <body>
     <div id="game-container"></div>
-    <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,0 @@
-document.addEventListener('DOMContentLoaded', () => {
-    console.log('Wordbuild game initialized.');
-});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wordbuild",
   "version": "0.1.0",
   "description": "Wordbuild Game",
-  "main": "main.js",
+  "main": "dist/bundle.js",
   "scripts": {
     "start": "webpack serve --open",
     "build": "webpack --mode production"

--- a/src/main.js
+++ b/src/main.js
@@ -1,48 +1,7 @@
 import Phaser from 'phaser';
+import gameConfig from './config/gameConfig';
 
-class BootScene extends Phaser.Scene {
-    constructor() {
-        super({ key: 'BootScene' });
-    }
-
-    preload() {
-        // Load any assets needed for the preloader or initial game state
-        console.log('BootScene preload');
-    }
-
-    create() {
-        console.log('BootScene create');
-        this.scene.start('GameScene');
-    }
-}
-
-class GameScene extends Phaser.Scene {
-    constructor() {
-        super({ key: 'GameScene' });
-    }
-
-    preload() {
-        console.log('GameScene preload');
-        // Load game assets here
-    }
-
-    create() {
-        console.log('GameScene create');
-        this.add.text(400, 300, 'Welcome to Wordbuild!', { fontSize: '32px', fill: '#fff' }).setOrigin(0.5);
-    }
-
-    update() {
-        // Game logic here
-    }
-}
-
-const config = {
-    type: Phaser.AUTO,
-    width: 800,
-    height: 600,
-    backgroundColor: '#1A2238',
-    parent: 'game-container', // This ID should be in your index.html
-    scene: [BootScene, GameScene]
-};
-
-const game = new Phaser.Game(config);
+window.addEventListener('load', () => {
+  // Initialize Phaser using the shared game configuration
+  new Phaser.Game(gameConfig);
+});


### PR DESCRIPTION
## Summary
- clean up entry HTML by dropping old script tag
- streamline Phaser bootstrap
- point package `main` at build output
- remove unused stub script

## Testing
- `npm start` *(fails: webpack not found)*